### PR TITLE
Onboard Brokers and IDP's

### DIFF
--- a/app/controllers/organisation_controller.rb
+++ b/app/controllers/organisation_controller.rb
@@ -6,8 +6,8 @@ class OrganisationController < ApplicationController
   def certificates
     org = Organisation.find_by_organisation_id(params[:organisation_id])
     render json: {
-      "signing": org.signing_cert.signed_certificate,
-      "transport": org.transport_cert.signed_certificate
+      "signing": org.signing_cert.public_key,
+      "transport": org.transport_cert.public_key
     }
   end
 

--- a/app/controllers/organisation_controller.rb
+++ b/app/controllers/organisation_controller.rb
@@ -1,6 +1,10 @@
 class OrganisationController < ApplicationController
   def register
-    Organisation.create(organisation_id: params[:client_id], org_type: 'service')
+    Organisation.create(
+      organisation_id: params[:client_id],
+      org_type: params[:organisation_type],
+      loa: params[:loa]
+    )
   end
 
   def certificates

--- a/app/controllers/organisation_controller.rb
+++ b/app/controllers/organisation_controller.rb
@@ -1,8 +1,10 @@
 class OrganisationController < ApplicationController
   def register
     Organisation.create(
+      name: params[:organisation_name],
       organisation_id: params[:client_id],
       org_type: params[:organisation_type],
+      domain: params[:domain],
       loa: params[:loa]
     )
   end
@@ -19,5 +21,18 @@ class OrganisationController < ApplicationController
     org = Organisation.find_by_organisation_id(params[:organisation_id])
     cert = org.public_send("#{params[:certificate_type]}_certificate").signed_certificate
     render json: { "#{params[:certificate_type]}": cert }
+  end
+
+  def list_orgs
+    orgs = Organisation.where(org_type: params[:organisation_type], revoked: false).map do |org|
+      {
+        name: org.name,
+        type: org.org_type,
+        domain: org.domain,
+        loa: org.loa
+      }
+    end
+
+    render json: orgs
   end
 end

--- a/app/controllers/ssa_controller.rb
+++ b/app/controllers/ssa_controller.rb
@@ -29,8 +29,8 @@ class SsaController < ApplicationController
     org = Organisation.find_by_organisation_id(params[:organisation_id])
     certs = org.ssa_certificates(params[:ssa_id])
     render json: {
-      "signing": certs.where(usage: 'signing').first.signed_certificate,
-      "transport": certs.where(usage: 'transport').first.signed_certificate
+      "signing": certs.where(usage: 'signing').first.public_key,
+      "transport": certs.where(usage: 'transport').first.public_key
     }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
 
   post '/organisation/:organisation_type', to: 'organisation#register'
 
+  get '/organisation/:organisation_type', to: 'organisation#list_orgs'
+
   post '/client-csr', to: 'certificate#generate'
 
   get '/certificate/transport/:client_id', to: 'certificate#directory_transport_cert'

--- a/db/migrate/20191111151227_add_loa_column_to_organisations.rb
+++ b/db/migrate/20191111151227_add_loa_column_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddLoaColumnToOrganisations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organisations, :loa, :string
+  end
+end

--- a/db/migrate/20191111155814_add_name_column_to_organisations.rb
+++ b/db/migrate/20191111155814_add_name_column_to_organisations.rb
@@ -1,0 +1,6 @@
+class AddNameColumnToOrganisations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organisations, :name, :string
+    add_column :organisations, :domain, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_11_151227) do
+ActiveRecord::Schema.define(version: 2019_11_11_155814) do
 
   create_table "certificates", force: :cascade do |t|
     t.integer "organisation_id"
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 2019_11_11_151227) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "loa"
+    t.string "name"
+    t.string "domain"
   end
 
   create_table "ssas", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_08_111932) do
+ActiveRecord::Schema.define(version: 2019_11_11_151227) do
 
   create_table "certificates", force: :cascade do |t|
     t.integer "organisation_id"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2019_11_08_111932) do
     t.boolean "revoked", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "loa"
   end
 
   create_table "ssas", force: :cascade do |t|


### PR DESCRIPTION
This now allows the onboarding of Brokers and IDPs into the directory. We now also capture their domain and the LOA if the organisation is an IDP.

This will provide the ability to list the domain servers for all types of organisation as well as fulfil the need to provide LOA for IDP types.

<img width="364" alt="Screenshot 2019-11-11 at 16 39 05" src="https://user-images.githubusercontent.com/3466862/68604498-891fd800-04a2-11ea-8f26-67e063e6c3f4.png">

<img width="393" alt="Screenshot 2019-11-11 at 16 40 23" src="https://user-images.githubusercontent.com/3466862/68604507-8b823200-04a2-11ea-8668-a47e0e7421f9.png">


The certificate endpoint was swapped back to return a public key string just for temporary convenience.

Corresponding onboarding app PR: https://github.com/alphagov/tpp-registration-prototype/pull/6